### PR TITLE
bugfix-4835/Fix for saving updated manifest data when parsing downloaded Bible

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -135,7 +135,9 @@ function addFileToParentDirectory(filePath) {
 
 function outputJsonSync(filePath, data) {
   addFileToParentDirectory(filePath);
-  mockFS[filePath] = data;
+  // clone data so changes to object do not affect object in file system
+  const clonedData = JSON.parse(JSON.stringify(data));
+  mockFS[filePath] = clonedData;
 }
 
 function readJsonSync(filePath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers/packageParseHelpers.js
+++ b/src/helpers/packageParseHelpers.js
@@ -75,7 +75,7 @@ export function parseBiblePackage(resourceEntry, extractedFilesPath, resultsPath
     }
 
     manifest.catalog_modified_time = resourceEntry.remoteModifiedTime;
-    let savePath = path.join(extractedFilesPath, 'manifest.json');
+    let savePath = path.join(resultsPath, 'manifest.json');
     fs.outputJsonSync(savePath, manifest);
 
     const projects = manifest.projects || [];


### PR DESCRIPTION
Made fix to location to save manifest changes when parsing downloaded Bible.

Fix to fs-extra mock to clone saved JSON data.  This was causing tests to pass when they shouldn't have