### PR TITLE
Fix - Removes old tW group data versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers/resourcesDownloadHelpers.js
+++ b/src/helpers/resourcesDownloadHelpers.js
@@ -60,6 +60,7 @@ export const downloadAndProcessResource = async (resource, resourcesPath) => {
         const twGroupDataResourcesPath = path.join(resourcesPath, resource.languageId, 'translationHelps', 'translationWords', 'v' + resource.version);
         try {
           await moveResourcesHelpers.moveResources(twGroupDataPath, twGroupDataResourcesPath);
+          removeAllButLatestVersion(path.dirname(twGroupDataResourcesPath));
         } catch (err) {
           throw Error(appendError(errors.UNABLE_TO_CREATE_TW_GROUP_DATA, err));
         }


### PR DESCRIPTION
Makes sure we also delete old versions of tW group data when a new original version Bible is published.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-source-content-updater/32)
<!-- Reviewable:end -->
