### PR TITLE
Bugfix 6145/retain old UGNT versions if needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import * as taArticleHelpers from './helpers/translationHelps/taArticleHelpers';
 import * as twArticleHelpers from './helpers/translationHelps/twArticleHelpers';
 import * as twGroupDataHelpers from './helpers/translationHelps/twGroupDataHelpers';
 import * as resourcesDownloadHelpers from './helpers/resourcesDownloadHelpers';
+export {getOtherTnsOLVersions} from './helpers/translationHelps/tnArticleHelpers';
 
 /**
  * Updater constructor


### PR DESCRIPTION
- exporting method getOtherTnsOLVersions() for use by tCore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/tc-source-content-updater/105)
<!-- Reviewable:end -->
