### PR TITLE
Allow multiple gl versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/src/helpers/resourcesDownloadHelpers.js
+++ b/src/helpers/resourcesDownloadHelpers.js
@@ -115,7 +115,6 @@ export const downloadAndProcessResource = async (resource, resourcesPath, downlo
       if (isGreekOrHebrew) versionsToNotDelete = getOtherTnsOLVersions(resourcePath, resource.languageId);
       // Make sure that the resource currently being downloaded is not deleted
       versionsToNotDelete.push('v' + resource.version);
-      removeAllButLatestVersion(path.dirname(resourcePath), versionsToNotDelete);
     } else {
       throw Error(errors.FAILED_TO_PROCESS_RESOURCE);
     }

--- a/src/helpers/resourcesDownloadHelpers.js
+++ b/src/helpers/resourcesDownloadHelpers.js
@@ -100,7 +100,6 @@ export const downloadAndProcessResource = async (resource, resourcesPath, downlo
         const twGroupDataResourcesPath = path.join(resourcesPath, resource.languageId, 'translationHelps', 'translationWords', 'v' + resource.version);
         try {
           await moveResourcesHelpers.moveResources(twGroupDataPath, twGroupDataResourcesPath);
-          removeAllButLatestVersion(path.dirname(twGroupDataResourcesPath));
         } catch (err) {
           throw Error(appendError(errors.UNABLE_TO_CREATE_TW_GROUP_DATA, err));
         }

--- a/src/helpers/translationHelps/tnArticleHelpers.js
+++ b/src/helpers/translationHelps/tnArticleHelpers.js
@@ -194,11 +194,6 @@ function getMissingOriginalResource(resourcesPath, originalLanguageId, originalL
       const versionsToNotDelete = getOtherTnsOLVersions(resourcesPath, originalLanguageId);
       const versionsSubdirectory = originalBiblePath.replace(version, '');
       const latestOriginalBiblePath = resourcesHelpers.getLatestVersionInPath(versionsSubdirectory);
-      // if latest version is the version needed delete older versions
-      if (latestOriginalBiblePath === originalBiblePath) {
-        // Old versions of the orginal language resource bible will be deleted because the tn uses the latest version and not an older version
-        resourcesHelpers.removeAllButLatestVersion(versionsSubdirectory, versionsToNotDelete);
-      }
       // If version needed is not in the resources download it.
       if (!fs.existsSync(originalBiblePath)) {
         // Download orig. lang. resource


### PR DESCRIPTION
Related to https://github.com/unfoldingword/translationcore/issues/7121

The updater no longer deletes old resources versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-source-content-updater/130)
<!-- Reviewable:end -->
