### PR TITLE
Updates Catalog Endpoint URLs

### DIFF
--- a/__tests__/_apiIntegration.test.js
+++ b/__tests__/_apiIntegration.test.js
@@ -409,7 +409,7 @@ describe.skip('apiHelpers compare pivoted.json with CN', () => {
 
 describe.skip('apiHelpers.getCatalogCN', () => {
   it('should get the CN catalog', async () => {
-    const unFilteredSearch = 'https://git.door43.org/api/catalog/v5/search?sort=subject&limit=50';
+    const unFilteredSearch = 'https://git.door43.org/api/v1/catalog/search?sort=subject&limit=50';
     const data = await apiHelpers.doMultipartQuery(unFilteredSearch);
     console.log(`Catalog Next Found ${data.length} total items`);
     expect(data.length).toBeTruthy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "tc-source-content-updater",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.12",
+      "name": "tc-source-content-updater",
+      "version": "1.4.13",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.4.11",
@@ -9883,7 +9884,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -12191,7 +12193,8 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.11.0.tgz",
       "integrity": "sha512-z541Fs5TFaY7/35v/z100InQ2f3V2J7e3u/0yKrnImgsHjh6JWgSRngfC/mZepn/+XN16jUydt64k//kxXc1fw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-jest": {
       "version": "22.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/src/helpers/apiHelpers.js
+++ b/src/helpers/apiHelpers.js
@@ -368,7 +368,7 @@ export async function searchCatalogNext(searchParams, retries=3) {
   } = searchParams;
 
   try {
-    let fetchUrl = `https://git.door43.org/api/catalog/v5/search`;
+    let fetchUrl = `https://git.door43.org/api/v1/catalog/search`;
     let parameters = '';
     parameters = addUrlParameter(owner, parameters, 'owner');
     parameters = addUrlParameter(languageId, parameters, 'lang');
@@ -401,7 +401,7 @@ export async function searchCatalogNext(searchParams, retries=3) {
  * @return {Promise<{Object}>}
  */
 export async function downloadManifestData(owner, repo, tag = 'master', retries=5) {
-  const fetchUrl = `https://git.door43.org/api/catalog/v5/entry/${owner}/${repo}/${tag}/metadata`;
+  const fetchUrl = `https://git.door43.org/api/v1/catalog/entry/${owner}/${repo}/${tag}/metadata`;
   try {
     const {result} = await makeJsonRequestDetailed(fetchUrl, retries);
     return result;
@@ -420,7 +420,7 @@ export async function downloadManifestData(owner, repo, tag = 'master', retries=
  * @return {Promise<{Object}>}
  */
 export async function getLatestRelease(owner, repo, retries=5, stage = null) {
-  let fetchUrl = `https://git.door43.org/api/catalog/v5/search/${owner}/${repo}`;
+  let fetchUrl = `https://git.door43.org/api/v1/catalog/search/${owner}/${repo}`;
   if (stage) {
     fetchUrl += `?stage=${stage}`;
   }
@@ -446,7 +446,7 @@ export async function getLatestRelease(owner, repo, retries=5, stage = null) {
  * @return {Promise<{Object}>}
  */
 export async function getReleaseMetaData(owner, repo, tag, retries=5) {
-  const fetchUrl = `https://git.door43.org/api/catalog/v5/entry/${owner}/${repo}/${tag}`;
+  const fetchUrl = `https://git.door43.org/api/v1/catalog/entry/${owner}/${repo}/${tag}`;
   try {
     const {result} = await makeJsonRequestDetailed(fetchUrl, retries);
     return result;


### PR DESCRIPTION
Endpoints on DCS have changed to use the main Gitea/DCS API v1 endpoints. Redirects are in place, but this should be updated to the permanent URLs.