### PR TITLE
Fixes Catalog Query for DCS v1.20 and earlier

### DIFF
--- a/__tests__/_apiIntegration.test.js
+++ b/__tests__/_apiIntegration.test.js
@@ -409,7 +409,7 @@ describe.skip('apiHelpers compare pivoted.json with CN', () => {
 
 describe.skip('apiHelpers.getCatalogCN', () => {
   it('should get the CN catalog', async () => {
-    const unFilteredSearch = 'https://git.door43.org/api/v1/catalog/search?sort=subject&limit=50';
+    const unFilteredSearch = 'https://git.door43.org/api/v1/catalog/search?metadataType=rc&sort=subject&limit=50';
     const data = await apiHelpers.doMultipartQuery(unFilteredSearch);
     console.log(`Catalog Next Found ${data.length} total items`);
     expect(data.length).toBeTruthy();

--- a/__tests__/apiHelpers.test.js
+++ b/__tests__/apiHelpers.test.js
@@ -13,8 +13,11 @@ describe('apiHelpers.getCatalog', () => {
         expectMemberType(item, idx, 'languageId', 'string');
         expectMemberType(item, idx, 'resourceId', 'string');
         expectMemberType(item, idx, 'full_name', 'string');
-        if (typeof item['checking_level'] !== 'number') { // can be either number or string type
-          expectMemberType(item, idx, 'checking_level', 'string');
+        const key = 'checking_level';
+        const value = item[key];
+        const checkingLevelType = typeof value;
+        if ( !value || !(checkingLevelType === 'number' || checkingLevelType === 'string')) {
+          console.log(`For resource at ${idx}, value '${value}' for key '${key} should be type number or string, not '${checkingLevelType}' - ${JSON.stringify(item)}`);
         }
         expectMemberType(item, idx, 'modified', 'string');
         expectMemberType(item, idx, 'subject', 'string');

--- a/__tests__/apiHelpers.test.js
+++ b/__tests__/apiHelpers.test.js
@@ -13,7 +13,9 @@ describe('apiHelpers.getCatalog', () => {
         expectMemberType(item, idx, 'languageId', 'string');
         expectMemberType(item, idx, 'resourceId', 'string');
         expectMemberType(item, idx, 'full_name', 'string');
-        expectMemberType(item, idx, 'checking_level', 'string');
+        if (typeof item['checking_level'] !== 'number') { // can be either number or string type
+          expectMemberType(item, idx, 'checking_level', 'string');
+        }
         expectMemberType(item, idx, 'modified', 'string');
         expectMemberType(item, idx, 'subject', 'string');
         expectMemberType(item, idx, 'title', 'string');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tc-source-content-updater",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tc-source-content-updater",
-      "version": "1.4.17",
+      "version": "1.4.18",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.4.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "tc-source-content-updater",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.16",
+      "name": "tc-source-content-updater",
+      "version": "1.4.17",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-source-content-updater",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "description": "Module that updates source content for the desktop application translationCore.",
   "main": "lib/index.js",
   "display": "library",

--- a/src/helpers/apiHelpers.js
+++ b/src/helpers/apiHelpers.js
@@ -115,7 +115,7 @@ export async function doMultipartQuery(url, retries = 5) {
  */
 async function searchSubjects(subjects, owner, retries=3) {
   const subjectParam = encodeURI(subjects.join(','));
-  let fetchUrl = `${DCS_BASE_URL}/api/catalog/v3/search?subject=${subjectParam}`;
+  let fetchUrl = `${DCS_BASE_URL}/api/v1/catalog/search?metadataType=rc&subject=${subjectParam}`;
   if (owner) {
     fetchUrl += fetchUrl + `&owner=${owner}`;
   }

--- a/src/helpers/apiHelpers.js
+++ b/src/helpers/apiHelpers.js
@@ -381,7 +381,7 @@ export async function searchCatalogNext(searchParams, retries=3) {
     parameters = addUrlParameter(stage, parameters, 'stage');
     parameters = addUrlParameter(checkingLevel, parameters, 'checkingLevel');
     parameters = addUrlParameter(partialMatch, parameters, 'partialMatch');
-    paramaters = addUrlParameter('rc', parameters, 'metadataType');
+    parameters = addUrlParameter('rc', parameters, 'metadataType');
     parameters = addUrlParameter(sort, parameters, 'sort');
     if (parameters) {
       fetchUrl += '?' + parameters;

--- a/src/helpers/apiHelpers.js
+++ b/src/helpers/apiHelpers.js
@@ -372,7 +372,7 @@ export async function searchCatalogNext(searchParams, retries=3) {
   } = searchParams;
 
   try {
-    let fetchUrl = `${baseUrl}/api/catalog/v5/search`;
+    let fetchUrl = `${baseUrl}/api/v1/catalog/search`;
     let parameters = '';
     parameters = addUrlParameter(owner, parameters, 'owner');
     parameters = addUrlParameter(languageId, parameters, 'lang');
@@ -381,6 +381,7 @@ export async function searchCatalogNext(searchParams, retries=3) {
     parameters = addUrlParameter(stage, parameters, 'stage');
     parameters = addUrlParameter(checkingLevel, parameters, 'checkingLevel');
     parameters = addUrlParameter(partialMatch, parameters, 'partialMatch');
+    paramaters = addUrlParameter('rc', parameters, 'metadataType');
     parameters = addUrlParameter(sort, parameters, 'sort');
     if (parameters) {
       fetchUrl += '?' + parameters;
@@ -406,7 +407,7 @@ export async function searchCatalogNext(searchParams, retries=3) {
  * @return {Promise<{Object}>}
  */
 export async function downloadManifestData({owner, repo, tag = 'master', retries = 5, baseUrl = DCS_BASE_URL}) {
-  const fetchUrl = `${baseUrl}/api/catalog/v5/entry/${owner}/${repo}/${tag}/metadata`;
+  const fetchUrl = `${baseUrl}/api/v1/catalog/entry/${owner}/${repo}/${tag}/metadata`;
   try {
     const {result} = await makeJsonRequestDetailed(fetchUrl, retries);
     return result;
@@ -426,7 +427,7 @@ export async function downloadManifestData({owner, repo, tag = 'master', retries
  * @return {Promise<{Object}>}
  */
 export async function getLatestRelease({owner, repo, retries = 5, stage = null, baseUrl = DCS_BASE_URL}) {
-  let fetchUrl = `${baseUrl}/api/catalog/v5/search/${owner}/${repo}`;
+  let fetchUrl = `${baseUrl}/api/v1/catalog/search/${owner}/${repo}`;
   if (stage) {
     fetchUrl += `?stage=${stage}`;
   }
@@ -453,7 +454,7 @@ export async function getLatestRelease({owner, repo, retries = 5, stage = null, 
  * @return {Promise<{Object}>}
  */
 export async function getReleaseMetaData({owner, repo, tag, retries = 5, baseUrl = DCS_BASE_URL}) {
-  const fetchUrl = `${baseUrl}/api/catalog/v5/entry/${owner}/${repo}/${tag}`;
+  const fetchUrl = `${baseUrl}/api/v1/catalog/entry/${owner}/${repo}/${tag}`;
   try {
     const {result} = await makeJsonRequestDetailed(fetchUrl, retries);
     return result;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- The Catalog URLs were using an old catalog/v5 that gets redirected in the proxy to v1/catalog. Better to have the actual URL
- Adds parameter metadataType=rc to the catalog search URL so to not get metadata types it doesn't support (sb, ts, etc.)

#### Please include detailed Test instructions for your pull request:
- Do a source content update, verify only "rc" repos are returned.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
